### PR TITLE
Switch to aws public repo for fluent bit, other improvements

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -28,7 +28,7 @@ module "autoscaling" {
   target_group_arns = var.app_type == "web" ? module.alb[0].target_group_arns : []
   user_data         = var.ecs_launch_type == "EC2" ? data.template_file.asg_ecs_ec2_user_data.rendered : null
 
-  vpc_zone_identifier       = var.private_subnets
+  vpc_zone_identifier       = var.public_ecs_service ? var.public_subnets : var.private_subnets
   health_check_type         = var.autoscaling_health_check_type
   min_size                  = var.min_size
   max_size                  = var.max_size

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ module "service" {
 
   web_proxy_enabled     = var.web_proxy_enabled
   ecs_exec_enabled      = var.ecs_exec_enabled
-  subnets               = var.public_service ? var.public_subnets : var.private_subnets
+  subnets               = var.public_ecs_service ? var.public_subnets : var.private_subnets
 
   # length(var.cloudwatch_schedule_expressions) > 1 means that it is cron task and desired_count should be 0
   cloudwatch_schedule_expressions = var.cloudwatch_schedule_expressions

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ locals {
   fluentbit_container_definition = [
     {
       essential         = true
-      image             = "amazon/aws-for-fluent-bit:latest"
+      image             = "public.ecr.aws/aws-observability/aws-for-fluent-bit:latest"
       name              = "log_router"
       memoryReservation = 75
       firelensConfiguration = {
@@ -162,7 +162,7 @@ variable "app_secrets" {
   default     = []
 }
 
-variable "public_service" {
+variable "public_ecs_service" {
   description = "It's publicity accessible service"
   type        = bool
   default     = false


### PR DESCRIPTION
- Switch to aws public repo for fluent bit
- Rename public_service to public_ecs_service
- Autoscaling honors public_ecs_service