### PR TITLE
ECS EC2 Improvements

### DIFF
--- a/ecs-modules/ecs-service/main.tf
+++ b/ecs-modules/ecs-service/main.tf
@@ -18,19 +18,27 @@ module "task" {
 
   docker_container_links = var.docker_container_links
 
-  environment    = var.environment # Non-secret Environment variables
+  environment    = var.environment
+  # Non-secret Environment variables
   app_secrets    = local.app_secrets
   global_secrets = local.global_secrets
 
-  cpu                           = var.cpu
-  memory                        = var.memory
-  volumes                       = var.volumes
-  resource_requirements         = var.resource_requirements
-  iam_role_policy_statement     = var.iam_role_policy_statement
-  sidecar_container_definitions = var.sidecar_container_definitions
-  firelens_ecs_log_enabled      = var.firelens_ecs_log_enabled
+  cpu                                        = var.cpu
+  memory                                     = var.memory
+  volumes                                    = var.volumes
+  resource_requirements                      = var.resource_requirements
+  iam_role_policy_statement                  = var.iam_role_policy_statement
+  sidecar_container_definitions              = var.sidecar_container_definitions
+  additional_container_definition_parameters = var.additional_container_definition_parameters
+  firelens_ecs_log_enabled                   = var.firelens_ecs_log_enabled
+  tmpfs_enabled                              = var.tmpfs_enabled
+  tmpfs_size                                 = var.tmpfs_size
+  tmpfs_container_path                       = var.tmpfs_container_path
+  tmpfs_mount_options                        = var.tmpfs_mount_options
+  shared_memory_size = var.shared_memory_size
 
-  port_mappings = var.web_proxy_enabled ? [] : var.port_mappings # We don't forward ports from the container if we are using proxy (proxy reaches out to container via internal network)
+  port_mappings = var.web_proxy_enabled ? [] : var.port_mappings
+  # We don't forward ports from the container if we are using proxy (proxy reaches out to container via internal network)
 }
 
 
@@ -71,7 +79,9 @@ resource "aws_ecs_service" "this" {
 
 
   dynamic "service_registries" {
-    for_each = (var.ecs_launch_type == "FARGATE" && var.ecs_service_discovery_enabled) ? [1] : []
+    for_each = (var.ecs_launch_type == "FARGATE" && var.ecs_service_discovery_enabled) ? [
+      1
+    ] : []
     content {
       registry_arn = var.ecs_service_discovery_enabled ? aws_service_discovery_service.this.arn : ""
       port         = var.docker_container_port
@@ -79,7 +89,9 @@ resource "aws_ecs_service" "this" {
   }
 
   dynamic "network_configuration" {
-    for_each = var.ecs_launch_type == "FARGATE" ? [1] : []
+    for_each = var.ecs_launch_type == "FARGATE" ? [
+      1
+    ] : []
     content {
       subnets          = var.subnets
       security_groups  = var.security_groups
@@ -88,12 +100,14 @@ resource "aws_ecs_service" "this" {
   }
 
   dynamic "load_balancer" {
-    for_each = [for p in var.port_mappings : {
+    for_each = [
+    for p in var.port_mappings : {
       container_name   = p.container_name
       target_group_arn = p.target_group_arn
       container_port   = p.container_port
 
-    }]
+    }
+    ]
 
     content {
       target_group_arn = load_balancer.value.target_group_arn
@@ -103,7 +117,9 @@ resource "aws_ecs_service" "this" {
   }
 
   dynamic "placement_constraints" {
-    for_each = var.ecs_launch_type == "EC2" ? [1] : []
+    for_each = var.ecs_launch_type == "EC2" ? [
+      1
+    ] : []
     content {
       type       = "memberOf"
       expression = "attribute:service-group == ${var.ec2_service_group}"
@@ -137,7 +153,9 @@ resource "aws_ecs_service" "this_deployed" {
   enable_execute_command             = var.ecs_exec_enabled
 
   dynamic "service_registries" {
-    for_each = (var.ecs_launch_type == "FARGATE" && var.ecs_service_discovery_enabled) ? [1] : []
+    for_each = (var.ecs_launch_type == "FARGATE" && var.ecs_service_discovery_enabled) ? [
+      1
+    ] : []
     content {
       registry_arn = var.ecs_service_discovery_enabled ? aws_service_discovery_service.this.arn : ""
       port         = var.docker_container_port
@@ -145,7 +163,9 @@ resource "aws_ecs_service" "this_deployed" {
   }
 
   dynamic "network_configuration" {
-    for_each = var.ecs_launch_type == "FARGATE" ? [1] : []
+    for_each = var.ecs_launch_type == "FARGATE" ? [
+      1
+    ] : []
     content {
       subnets          = var.subnets
       security_groups  = var.security_groups
@@ -154,11 +174,13 @@ resource "aws_ecs_service" "this_deployed" {
   }
 
   dynamic "load_balancer" {
-    for_each = [for p in var.port_mappings : {
+    for_each = [
+    for p in var.port_mappings : {
       container_name   = p.container_name
       container_port   = p.container_port
       target_group_arn = p.target_group_arn
-    }]
+    }
+    ]
 
     content {
       target_group_arn = load_balancer.value.target_group_arn
@@ -168,7 +190,9 @@ resource "aws_ecs_service" "this_deployed" {
   }
 
   dynamic "placement_constraints" {
-    for_each = var.ecs_launch_type == "EC2" ? [1] : []
+    for_each = var.ecs_launch_type == "EC2" ? [
+      1
+    ] : []
     content {
       type       = "memberOf"
       expression = "attribute:service-group == ${var.ec2_service_group}"

--- a/ecs-modules/ecs-service/variables.tf
+++ b/ecs-modules/ecs-service/variables.tf
@@ -152,6 +152,13 @@ variable "sidecar_container_definitions" {
   default     = []
 }
 
+variable "additional_container_definition_parameters" {
+  type        = any
+  description = "Additional parameters passed straight to the container definition, eg. tmpfs config"
+  default     = {}
+}
+
+
 variable "iam_role_policy_statement" {
   type        = list(any)
   description = "ECS Service IAM Role policy statement"
@@ -169,14 +176,14 @@ variable "ecs_launch_type" {
   }
 }
 
-# The var.cpu & var.memory vars are valid only for FARGATE. EC2 instance type is used to set ECS EC2 specs 
+# The var.cpu & var.memory vars are valid only for FARGATE. EC2 instance type is used to set ECS EC2 specs
 variable "cpu" {
   type        = number
   default     = 256
   description = "Fargate CPU value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
 
   validation {
-    condition     = can(regex("256|512|1024|2048|4096", var.cpu))
+    condition     =  can(regex("256|512|1024|2048|4096", var.cpu))
     error_message = "The cpu value must be a valid CPU value, https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html."
   }
 }
@@ -346,4 +353,35 @@ variable "firelens_ecs_log_enabled" {
   type        = bool
   description = "AWSFirelens ECS logs enabled"
   default     = false
+}
+
+variable "tmpfs_enabled" {
+  type = bool
+  description = "TMPFS support for non-Fargate deployments"
+  default = false
+}
+
+variable "tmpfs_size" {
+  type = number
+  description = "Size of the tmpfs in MB"
+  default = 1024
+}
+
+variable "tmpfs_container_path" {
+  type = string
+  description = "Path where tmpfs shm would be mounted"
+  default = "/tmp/"
+}
+
+
+variable "tmpfs_mount_options" {
+  type = list(string)
+  description = "Options for the mount of the ram disk. noatime by default to speed up access"
+  default = ["noatime"]
+}
+
+variable "shared_memory_size" {
+  type = number
+  description = "Size of the /dev/shm shared memory in MB"
+  default = 0
 }

--- a/ecs-modules/ecs-task/main.tf
+++ b/ecs-modules/ecs-task/main.tf
@@ -2,8 +2,8 @@ resource "aws_ecs_task_definition" "this" {
   family             = var.ecs_task_family_name != "" ? var.ecs_task_family_name : "${var.env}-${var.name}"
   execution_role_arn = aws_iam_role.ecs_execution.arn
   task_role_arn      = aws_iam_role.ecs_task_role.arn
-  cpu                = var.cpu
-  memory             = var.memory
+  cpu                = var.ecs_launch_type == "FARGATE" ? var.cpu : null
+  memory             = var.ecs_launch_type == "FARGATE" ? var.memory : null
 
   dynamic "volume" {
     for_each = var.volumes
@@ -44,7 +44,9 @@ resource "aws_ecs_task_definition" "this" {
     }
   }
   network_mode             = var.ecs_network_mode
-  requires_compatibilities = [var.ecs_launch_type]
+  requires_compatibilities = [
+    var.ecs_launch_type
+  ]
   container_definitions    = jsonencode(local.container_definitions)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -288,6 +288,12 @@ variable "docker_container_port" {
   default     = 3000
 }
 
+variable "docker_host_port" {
+  description = "Docker host port. 0 means Auto-assign."
+  type        = number
+  default     = 0
+}
+
 variable "docker_container_entrypoint" {
   type        = list(string)
   description = "Docker container entrypoint"
@@ -464,7 +470,7 @@ variable "cpu" {
   description = "Fargate CPU value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
 
   validation {
-    condition     = can(regex("256|512|1024|2048|4096", var.cpu))
+    condition     =  can(regex("256|512|1024|2048|4096", var.cpu))
     error_message = "The cpu value must be a valid CPU value, https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html."
   }
 }
@@ -632,4 +638,41 @@ variable "ecs_exec_enabled" {
   type        = bool
   description = "Turns on the Amazon ECS Exec for the task"
   default     = true
+}
+
+variable "additional_container_definition_parameters" {
+  type        = any
+  description = "Additional parameters passed straight to the container definition, eg. tmpfs config"
+  default     = {}
+}
+
+
+variable "tmpfs_enabled" {
+  type = bool
+  description = "TMPFS support for non-Fargate deployments"
+  default = false
+}
+
+variable "tmpfs_size" {
+  type = number
+  description = "Size of the tmpfs in MB"
+  default = 1024
+}
+
+variable "tmpfs_container_path" {
+  type = string
+  description = "Path where tmpfs shm would be mounted"
+  default = "/tmp/"
+}
+
+variable "tmpfs_mount_options" {
+  type = list(string)
+  description = "Options for the mount of the ram disk. noatime by default to speed up access"
+  default = ["noatime"]
+}
+
+variable "shared_memory_size" {
+  type = number
+  description = "Size of the /dev/shm shared memory in MB"
+  default = 0
 }


### PR DESCRIPTION
- Add ability to set external ports
- Add additional container_def_parameters wildcard section
- Add tmpfs support
- Add shared_memory support
- Ignore memory and cpu in task definition for EC2 launch type
- Use public subnets if it's a public ecs service
- Reformat