### PR TITLE
TCP TLS listeners support HTTPS

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -28,7 +28,7 @@ module "autoscaling" {
   key_name                     = var.key_name
 
   # EC2 Instance Profile
-  create_iam_instance_profile   = true
+  create_iam_instance_profile   = var.ecs_launch_type == "EC2" ? var.create_iam_instance_profile : false
   iam_instance_profile_name     = "${var.env}-${var.namespace}"
   iam_role_name                 = "${var.env}-${var.namespace}-ec2-profile-role"
   iam_role_path                 = "/ec2/"

--- a/locals.tf
+++ b/locals.tf
@@ -117,6 +117,22 @@ locals {
         target_group_index = 0
       },]
 
+  https_listeners = var.app_type == "tcp-app" ? [
+    for index, port_mapping in var.port_mappings :
+      {
+        port               = port_mapping.host_port
+        protocol           = "TCP"
+        certificate_arn    = var.tls_cert_arn
+        target_group_index = index
+      }
+    ] : [
+      {
+        port               = 443
+        protocol           = "HTTPS"
+        certificate_arn    = var.tls_cert_arn
+        target_group_index = 0
+      },]
+
   ecs_service_tcp_port_mappings = [
     for index, port_mapping in var.port_mappings :
       {

--- a/locals.tf
+++ b/locals.tf
@@ -109,7 +109,7 @@ locals {
         port               = port_mapping.host_port
         protocol           = "TCP"
         target_group_index = index
-      }
+      } if port_mapping.https_listener == false
     ] : [
       {
         port               = var.http_port
@@ -117,14 +117,14 @@ locals {
         target_group_index = 0
       },]
 
-  https_listeners = var.app_type == "tcp-app" ? [
+  https_tls_listeners = var.app_type == "tcp-app" ? [
     for index, port_mapping in var.port_mappings :
       {
         port               = port_mapping.host_port
-        protocol           = "TCP"
+        protocol           = "TLS"
         certificate_arn    = var.tls_cert_arn
         target_group_index = index
-      }
+      } if port_mapping.https_listener == true
     ] : [
       {
         port               = 443
@@ -185,7 +185,7 @@ locals {
         port                = port_mapping.host_port
         protocol            = "TCP"
       }
-
+      
     }
   ]
   

--- a/main.tf
+++ b/main.tf
@@ -13,20 +13,9 @@ module "alb" {
   idle_timeout       = var.alb_idle_timeout
 
   http_tcp_listeners = local.http_tcp_listeners
+  https_listeners    = var.https_enabled ? concat(local.https_listeners) : []
 
-
-  https_listeners = var.app_type == "web" && var.https_enabled ? concat(
-  [
-    {
-      port               = 443
-      protocol           = "HTTPS"
-      certificate_arn    = var.tls_cert_arn
-      target_group_index = 0
-    }
-  ]) : []
-
-  target_groups = concat(var.app_type == "web" ? local.target_groups_web : local.target_groups_tcp)
-
+  target_groups      = concat(var.app_type == "web" ? local.target_groups_web : local.target_groups_tcp)
 
   tags = {
     env = var.env

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ module "alb" {
   idle_timeout       = var.alb_idle_timeout
 
   http_tcp_listeners = local.http_tcp_listeners
-  https_listeners    = var.https_enabled ? concat(local.https_listeners) : []
+  https_listeners    = var.https_enabled ? concat(local.https_tls_listeners) : []
 
   target_groups      = concat(var.app_type == "web" ? local.target_groups_web : local.target_groups_tcp)
 


### PR DESCRIPTION
https://selenium-hub.dev-oregon.bot-it.hzl.xyz:4444
![image](https://user-images.githubusercontent.com/10009103/194578737-1e7a3df9-6598-4713-ba05-c176f3241cc2.png)

Passing port mapping looks like:
````

  port_mappings = [
    {
      container_port = 4442
      host_port      = 4442
      https_listener = false
    },
    {
      container_port = 4443
      host_port      = 4443
      https_listener = false
    },
    {
      container_port = 4444
      host_port      = 4444
      https_listener = true
    }
  ]
````