### PR TITLE
TCP mode Updates

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,11 +1,13 @@
 locals {
-  name             = var.app_type == "tcp-app" ? "${var.env}-${var.name}-tcp" : "${var.env}-${var.name}"
+  name             = "${var.env}-${var.name}"
   ecs_service_name = var.ecs_service_name != "" ? var.ecs_service_name : "${var.env}-${var.name}"
   ecs_cluster_name = var.ecs_cluster_name != "" ? var.ecs_cluster_name : "${var.env}-${var.namespace}"
   ecs_cluster_arn  = length(var.ecs_cluster_arn) != "" ? var.ecs_cluster_arn : "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${local.ecs_cluster_name}"
   ecr_repo_name    = var.ecr_repo_name != "" ? var.ecr_repo_name : "${var.namespace}-${var.name}"
   name_prefix      = "${substr(var.name, 0, 5)}-"
-  domain_names     = var.root_domain_name != "example.com" ? concat(["${var.name}.${var.env}.${var.root_domain_name}"], var.domain_names) : []
+  domain_names     = var.root_domain_name != "example.com" ? concat([
+    "${var.name}.${var.env}.${var.root_domain_name}"
+  ], var.domain_names) : []
 
   # Datadog Environment Variables: https://docs.datadoghq.com/agent/guide/environment-variables/
   #                                https://docs.datadoghq.com/agent/docker/apm/?tab=linux#docker-apm-agent-environment-variables
@@ -31,12 +33,12 @@ locals {
 
   fluentbit_container_definition = [
     {
-      essential         = true
-      image             = "public.ecr.aws/aws-observability/aws-for-fluent-bit:latest"
-      name              = "log_router"
-      memoryReservation = 75
+      essential             = true
+      image                 = "public.ecr.aws/aws-observability/aws-for-fluent-bit:latest"
+      name                  = "log_router"
+      memoryReservation     = 75
       firelensConfiguration = {
-        "type" = "fluentbit"
+        "type"    = "fluentbit"
         "options" = {
           "enable-ecs-log-metadata" = "true"
         }
@@ -46,43 +48,45 @@ locals {
 
   volumes = concat(var.web_proxy_enabled ? [
     {
-      name = "nginx-templates",
+      name        = "nginx-templates",
       mount_point = {
         "sourceVolume"  = "nginx-templates"
         "containerPath" = "/etc/nginx/templates/"
         "readOnly"      = null
       }
 
-      docker_volume_configuration = [{
-        "scope" : "task",
-        "driver" : "local",
-        "labels" : {
-          "scratch" : "space"
+      docker_volume_configuration = [
+        {
+          "scope" : "task",
+          "driver" : "local",
+          "labels" : {
+            "scratch" : "space"
+          }
         }
-      }]
+      ]
     },
     {
-      name = "nginx-app",
+      name        = "nginx-app",
       mount_point = {
         "sourceVolume"  = "nginx-app"
         "containerPath" = "/etc/nginx/app/"
         "readOnly"      = null
       }
 
-      docker_volume_configuration = [{
-        "scope" : "task",
-        "driver" : "local",
-        "labels" : {
-          "scratch" : "space"
+      docker_volume_configuration = [
+        {
+          "scope" : "task",
+          "driver" : "local",
+          "labels" : {
+            "scratch" : "space"
+          }
         }
-      }]
+      ]
     },
-  ]
-  : [],
-
+  ] : [],
     var.efs_enabled ? [
       {
-        name = "efs",
+        name        = "efs",
         mount_point = {
           "sourceVolume"  = "efs"
           "containerPath" = var.efs_mount_point,
@@ -103,45 +107,48 @@ locals {
     (var.datadog_enabled && var.ecs_launch_type == "EC2") ? module.datadog.volumes : []
   )
 
-  http_tcp_listeners = var.app_type == "tcp-app" ? [
+  alb_http_tcp_listeners = var.app_type == "tcp-app" ? [
     for index, port_mapping in var.port_mappings :
-      {
-        port               = port_mapping.host_port
-        protocol           = "TCP"
-        target_group_index = index
-      } if port_mapping.https_listener == false
+    {
+      port               = port_mapping["host_port"]
+      protocol           = "TCP"
+      target_group_index = index
+    } if ! lookup(port_mapping, "tls", false)
     ] : [
       {
         port               = var.http_port
         protocol           = "HTTP"
         target_group_index = 0
-      },]
+      }
+  ]
 
-  https_tls_listeners = var.app_type == "tcp-app" ? [
+  # In case app type is "tcp-app" and port_mapping has "tls" config and is true we use tcp over tls.
+  alb_https_listeners = var.app_type == "tcp-app" ? [
     for index, port_mapping in var.port_mappings :
-      {
-        port               = port_mapping.host_port
-        protocol           = "TLS"
-        certificate_arn    = var.tls_cert_arn
-        target_group_index = index
-      } if port_mapping.https_listener == true
-    ] : [
-      {
-        port               = 443
-        protocol           = "HTTPS"
-        certificate_arn    = var.tls_cert_arn
-        target_group_index = 0
-      },]
+    {
+      port               = port_mapping["host_port"]
+      protocol           = "TLS"
+      certificate_arn    = var.tls_cert_arn
+      target_group_index = index
+    } if lookup(port_mapping, "tls", false)
+  ] : [
+    {
+      port               = 443
+      protocol           = "HTTPS"
+      certificate_arn    = var.tls_cert_arn
+      target_group_index = 0
+    }
+  ]
 
   ecs_service_tcp_port_mappings = [
     for index, port_mapping in var.port_mappings :
-      {
-        container_name      = var.name
-        container_port      = port_mapping.container_port
-        host_port           = port_mapping.host_port
-        target_group_arn    = length(module.alb[*].target_group_arns) >= 1 ? module.alb[0].target_group_arns[index] : ""
-      }
-    ]
+    {
+      container_name   = var.name
+      container_port   = port_mapping["container_port"]
+      host_port        = port_mapping["host_port"]
+      target_group_arn = length(module.alb[*].target_group_arns) >= 1 ? module.alb[0].target_group_arns[index] : ""
+    }
+  ]
 
   target_groups_web = [
     {
@@ -150,6 +157,8 @@ locals {
       backend_port         = var.web_proxy_enabled ? var.web_proxy_docker_container_port : var.docker_container_port
       target_type          = var.ecs_launch_type == "EC2" ? "instance" : "ip"
       deregistration_delay = var.alb_deregistration_delay
+      preserve_client_ip   = true
+      # This is specified for compatibility with the tcp target groups. It's not actually used in a lookup.
 
       health_check = {
         enabled             = true
@@ -170,9 +179,10 @@ locals {
     {
       name_prefix          = local.name_prefix
       backend_protocol     = "TCP"
-      backend_port         = port_mapping.container_port
+      backend_port         = port_mapping["container_port"]
       target_type          = var.ecs_launch_type == "EC2" ? "instance" : "ip"
       deregistration_delay = var.alb_deregistration_delay
+      preserve_client_ip   = true
 
       health_check = {
         enabled             = true
@@ -182,11 +192,9 @@ locals {
         unhealthy_threshold = var.alb_health_check_unhealthy_threshold
         timeout             = null
         matcher             = null
-        port                = port_mapping.host_port
+        port                = port_mapping["host_port"]
         protocol            = "TCP"
       }
-      
     }
   ]
-  
 }

--- a/main.tf
+++ b/main.tf
@@ -5,17 +5,19 @@ module "alb" {
   version = "~> 7.0"
 
   name               = var.public ? local.name : "${local.name}-private"
-  load_balancer_type = var.app_type == "web" ? "application" : "network" 
+  load_balancer_type = var.app_type == "web" ? "application" : "network"
   internal           = var.public ? false : true
   vpc_id             = var.vpc_id
   security_groups    = var.alb_security_groups
   subnets            = var.public ? var.public_subnets : var.private_subnets
   idle_timeout       = var.alb_idle_timeout
 
-  http_tcp_listeners = local.http_tcp_listeners
-  https_listeners    = var.https_enabled ? concat(local.https_tls_listeners) : []
 
-  target_groups      = concat(var.app_type == "web" ? local.target_groups_web : local.target_groups_tcp)
+
+  http_tcp_listeners  = local.alb_http_tcp_listeners
+  https_listeners = var.https_enabled ? concat(local.alb_https_listeners) : []
+
+  target_groups = concat(var.app_type == "web" ? local.target_groups_web : local.target_groups_tcp)
 
   access_logs = var.alb_access_logs_enabled && var.alb_access_logs_s3bucket_name != "" ? {
     bucket = var.alb_access_logs_s3bucket_name

--- a/variables.tf
+++ b/variables.tf
@@ -200,7 +200,7 @@ variable "docker_host_port" {
 
 variable "port_mappings" {
   description = "List of ports to open from a service"
-  type = list(any)
+  type = any
   default = []
 }
 


### PR DESCRIPTION
- Ensure to preserve client ip so security groups work on the target
- Use lookup to pull tls config from the port mapping
- Use map host port call vs property
- Change back name to plain (no -tcp)
- Reformat