### PR TITLE
Add prefix to alb access logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ module "alb" {
 
   access_logs = var.alb_access_logs_enabled && var.alb_access_logs_s3bucket_name != "" ? {
     bucket = var.alb_access_logs_s3bucket_name
+    prefix = var.alb_access_logs_s3prefix
   } : {}
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -712,3 +712,9 @@ variable "alb_access_logs_s3bucket_name" {
   description = "S3 bucket name for ALB access logs"
   default     = ""
 }
+
+variable "alb_access_logs_s3prefix" {
+  type        = string
+  description = "S3 prefix for ALB access logs"
+  default     = ""
+}


### PR DESCRIPTION
This change will allow to include a Prefix when enabling access logs in ALB