### PR TITLE
Deprecated EIP parameter updated/ domain parameter added

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -2,7 +2,7 @@ resource "aws_eip" "autoscaling" {
   # If ec2_eip_count is set, use that number for number of EIPs, otherwise use var.max_size + 1 (but that might not be the best during downscaling and deletion of EIPs
   count            = var.ec2_eip_enabled ? (var.ec2_eip_count > 0 ? var.ec2_eip_count : var.max_size + 1) : 0
   public_ipv4_pool = "amazon"
-  domain = "vpc"
+  domain           = "vpc"
   tags = {
     Name    = "${local.name}-${count.index + 1}"
     env     = var.env

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -2,7 +2,7 @@ resource "aws_eip" "autoscaling" {
   # If ec2_eip_count is set, use that number for number of EIPs, otherwise use var.max_size + 1 (but that might not be the best during downscaling and deletion of EIPs
   count            = var.ec2_eip_enabled ? (var.ec2_eip_count > 0 ? var.ec2_eip_count : var.max_size + 1) : 0
   public_ipv4_pool = "amazon"
-
+  domain = "vpc"
   tags = {
     Name    = "${local.name}-${count.index + 1}"
     env     = var.env


### PR DESCRIPTION
#### What's new:

 - EIP deprecated parameter updated


#### Testing done:

<img width="1105" alt="Screenshot 2025-01-16 at 21 34 50" src="https://github.com/user-attachments/assets/e1fc0113-9dca-48ab-b96c-0a1b615a98b2" />
<img width="736" alt="Screenshot 2025-01-16 at 21 42 11" src="https://github.com/user-attachments/assets/b5622ae0-fb32-499b-b653-9f0e25c9d4fd" />
