### PR TITLE
CORE-961 EFS Module updated

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -1,19 +1,34 @@
 module "efs" {
-  source  = "registry.terraform.io/cloudposse/efs/aws"
-  version = "~> 0.36"
+  source  = "registry.terraform.io/terraform-aws-modules/efs/aws"
+  version = "~> 2.0"
 
-  enabled = var.efs_enabled && var.efs_share_create ? true : false
-  stage   = var.env
-  name    = var.name
-  region  = data.aws_region.current.name
-  vpc_id  = var.vpc_id
-  security_groups = var.security_groups
-  access_points = var.efs_access_points
+  create = var.efs_enabled && var.efs_share_create ? true : false
 
-  # This is a workaround for 2-zone legacy setups
-  subnets = length(regexall("legacy", var.env)) > 0 ? [
-    var.private_subnets[0],
-    var.private_subnets[1]
-  ] : var.private_subnets
+  name = var.name
 
+  create_security_group = true
+  security_group_vpc_id = var.vpc_id
+
+  security_group_ingress_rules = {
+    for idx, sg_id in var.security_groups :
+    "from_sg_${idx}" => {
+      referenced_security_group_id = sg_id
+      description                  = "NFS from application security group"
+    }
+  }
+
+  # Mount targets
+  mount_targets = {
+    for idx, subnet_id in (
+      length(regexall("legacy", var.env)) > 0 ? [
+      var.private_subnets[0],
+      var.private_subnets[1]
+    ] : var.private_subnets
+    ) : "mount-${idx}" => {
+      subnet_id = subnet_id
+    }
+  }
+
+  # Access points
+  access_points = local.efs_access_points
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,7 +32,7 @@ output "alb_arn" {
 
 output "efs_mount_target" {
   description = "DNS name of the EFS mount target (if EFS is created)"
-  value = var.efs_enabled && var.efs_share_create ? module.efs.mount_target_dns_names[0] : ""
+  value = var.efs_enabled && var.efs_share_create ? module.efs.dns_name : ""
 }
 
 output "eips" {

--- a/variables.tf
+++ b/variables.tf
@@ -622,22 +622,9 @@ variable "efs_authorization_config" {
 }
 
 variable "efs_access_points" {
-  type = object({})
-  description = "EFS access points"
-  default = {
-    "data" = {
-      posix_user = {
-        gid            = "1001"
-        uid            = "5000"
-        secondary_gids = "1002,1003"
-      }
-      creation_info = {
-        gid         = "1001"
-        uid         = "5000"
-        permissions = "0755"
-      }
-    }
-  }
+  type        = any
+  description = "EFS access points - map of access point definitions. See terraform-aws-modules/efs/aws documentation for format."
+  default     = {}
 }
 
 variable "ecs_service_deployed" {


### PR DESCRIPTION
#### What's new:

 - EFS module updated to aws-terraform-modules one
 - Logic updated
 - Default value moved to locals

#### Testing done:

Deploy terraform successful:
<img width="1706" height="701" alt="Screenshot 2025-12-04 at 17 01 19" src="https://github.com/user-attachments/assets/245727cb-3542-4920-b27f-1f438a652428" />

App deployed successfully:
<img width="1034" height="386" alt="Screenshot 2025-12-04 at 17 06 15" src="https://github.com/user-attachments/assets/31635323-4a51-423f-b51d-1289d369a719" />

EFS mounted:
<img width="1488" height="784" alt="Screenshot 2025-12-04 at 17 14 25" src="https://github.com/user-attachments/assets/f1c5d0d1-becf-44d9-a377-a42c819cbc18" />


EFS access test:
<img width="995" height="313" alt="Screenshot 2025-12-04 at 17 07 54" src="https://github.com/user-attachments/assets/258b594d-ebda-43a1-ac57-9c48d82bad68" />

