### PR TITLE
CORE-970 Amis integrated in the module

### DIFF
--- a/.github/workflows/run.e2e-tests.yml
+++ b/.github/workflows/run.e2e-tests.yml
@@ -111,7 +111,7 @@ jobs:
         if: always()
 
       - name: Upload test summary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-summary-${{ matrix.test_name }}
           path: test/test-summary-${{ matrix.test_name }}.md

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -21,7 +21,7 @@ module "autoscaling" {
   launch_template_name = local.name
 
   # Auto scaling group
-  image_id        = var.image_id
+  image_id        = var.image_id != null ? var.image_id : try(data.aws_ami.this[0].id, null)
   instance_type   = var.instance_type
   security_groups = var.security_groups
   key_name = var.key_name

--- a/data.tf
+++ b/data.tf
@@ -6,3 +6,21 @@ data "aws_iam_instance_profile" "this" {
   name  = module.autoscaling.iam_instance_profile_id
 }
 
+# Get latest AMI info for Amazon Linux 2023 ECS optimized
+data "aws_ami" "this" {
+  count       = var.ecs_launch_type == "EC2" && var.image_id == null ? 1 : 0
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-ecs-hvm-2023*-${lower(var.cpu_architecture)}"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["amazon"]
+}
+

--- a/locals.tf
+++ b/locals.tf
@@ -32,7 +32,6 @@ locals {
   # Use provided var.efs_access_points or fall back to default
   efs_access_points = length(var.efs_access_points) > 0 ? var.efs_access_points : local.efs_access_points_default
 
-
   # Datadog Environment Variables: https://docs.datadoghq.com/agent/guide/environment-variables/
   #                                https://docs.datadoghq.com/agent/docker/apm/?tab=linux#docker-apm-agent-environment-variables
   datadog_env_vars = var.datadog_enabled ? {


### PR DESCRIPTION
#### What's new:

 - AMI's added to the module.
 - If EC2 selected  and no image_id set - it will get image_id from data.tf 