### PR TITLE
CORE-964 Autoscaling module updated

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -22,7 +22,7 @@ module "autoscaling" {
   launch_template_name = local.name
 
   # Auto scaling group
-  image_id        = var.image_id
+  image_id        = var.image_id != null ? var.image_id : data.aws_ami.this[0].id
   instance_type   = var.instance_type
   security_groups = var.security_groups
   key_name        = var.key_name

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,3 +1,4 @@
+
 resource "aws_eip" "autoscaling" {
   # If ec2_eip_count is set, use that number for number of EIPs, otherwise use var.max_size + 1 (but that might not be the best during downscaling and deletion of EIPs
   count            = var.ec2_eip_enabled ? (var.ec2_eip_count > 0 ? var.ec2_eip_count : var.max_size + 1) : 0
@@ -12,19 +13,19 @@ resource "aws_eip" "autoscaling" {
 
 module "autoscaling" {
   source  = "terraform-aws-modules/autoscaling/aws"
-  version = "~> 6.0"
+  version = "~> 9.0"
 
   create                 = var.ecs_launch_type == "EC2" ? true : false
   create_launch_template = var.ecs_launch_type == "EC2" ? true : false
 
-  name = local.name
+  name                 = local.name
   launch_template_name = local.name
 
   # Auto scaling group
-  image_id        = var.image_id != null ? var.image_id : try(data.aws_ami.this[0].id, null)
+  image_id        = var.image_id
   instance_type   = var.instance_type
   security_groups = var.security_groups
-  key_name = var.key_name
+  key_name        = var.key_name
 
   # EC2 Instance Profile
   create_iam_instance_profile = var.ecs_launch_type == "EC2" ? var.create_iam_instance_profile : false
@@ -49,8 +50,16 @@ module "autoscaling" {
     }
   ]
 
-  target_group_arns = var.app_type == "web" || var.app_type == "tcp-app" ? module.alb[0].target_group_arns : []
-  user_data         = var.ecs_launch_type == "EC2" ? base64encode(local.asg_ecs_ec2_user_data) : null
+  # Autoscaling v9+ uses traffic_source_attachments instead of target_group_arns
+  traffic_source_attachments = var.app_type == "web" || var.app_type == "tcp-app" ? {
+    for idx, arn in values(module.alb[0].target_groups) :
+    "tg-${idx}" => {
+      traffic_source_identifier = arn.arn
+      traffic_source_type       = "elbv2"
+    }
+  } : null
+
+  user_data = var.ecs_launch_type == "EC2" ? base64encode(local.asg_ecs_ec2_user_data) : null
 
   vpc_zone_identifier       = var.public_ecs_service ? var.public_subnets : var.private_subnets
   health_check_type         = var.autoscaling_health_check_type
@@ -59,8 +68,8 @@ module "autoscaling" {
   desired_capacity          = var.desired_capacity
   wait_for_capacity_timeout = 0
 
-  create_schedule = var.create_schedule
-  schedules       = var.schedules
+  # Autoscaling module v9+ removed create_schedule variable, schedules are created if the map is not empty
+  schedules = var.schedules
 
   tags = {
     env            = var.env
@@ -78,7 +87,7 @@ resource "aws_iam_role_policy" "ec2_auto_eip" {
 
 
   policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [
       {
         Action = [

--- a/data.tf
+++ b/data.tf
@@ -23,4 +23,3 @@ data "aws_ami" "this" {
 
   owners = ["amazon"]
 }
-


### PR DESCRIPTION
#### What's new:

- Autoscaling module updated to latest version
- Terraform versions updated in linter.yml GHA

#### Testing done:

 Deploy successful:
<img width="763" height="295" alt="Screenshot 2025-12-09 at 14 16 51" src="https://github.com/user-attachments/assets/75b44306-480a-4c83-8d2f-5b37d712dc80" />

<img width="1480" height="510" alt="Screenshot 2025-12-11 at 15 42 56" src="https://github.com/user-attachments/assets/52cf5dc5-0a72-4510-aabe-44fcc03a953b" />
