### PR TITLE
CORE-966 NGINX module replaced / Linter updated

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        terraform_version: [1.5.6, 1.10.1] # Actual and latest versions used
+        terraform_version: [1.5.7, 1.14.2] # Actual and latest versions used
       fail-fast: false
     steps:
       - name: Checkout Code
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        terraform_version: [1.5.6, 1.10.1] # Actual and latest versions used
+        terraform_version: [1.5.7, 1.14.2] # Actual and latest versions used
       fail-fast: false
     steps:
       - name: Checkout Code

--- a/proxy.tf
+++ b/proxy.tf
@@ -1,6 +1,6 @@
 module "nginx" {
   source  = "registry.terraform.io/hazelops/ecs-nginx-proxy/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   app_name    = var.name
   env         = var.env

--- a/variables.tf
+++ b/variables.tf
@@ -243,7 +243,7 @@ variable "web_proxy_enabled" {
 variable "web_proxy_docker_image_tag" {
   type        = string
   description = "Nginx proxy docker image tag"
-  default     = "1.19.2-alpine"
+  default     = "1.28.0-alpine"
 }
 variable "proxy_docker_image_name" {
   type        = string


### PR DESCRIPTION
#### What's new:

 - Nginx proxy module version updated to the latest(2.0)
 - Nginx image version updated to 1.28.0-stable in variables.tf
 - Terraform version updated in GitHub Linter action

#### Testing done:
Deploy:
<img width="752" height="134" alt="Screenshot 2025-12-18 at 16 07 07" src="https://github.com/user-attachments/assets/0ef16646-35cc-4bd7-8bb0-5634c2bd96dd" />

In the task definition:
<img width="884" height="763" alt="Screenshot 2025-12-18 at 16 07 27" src="https://github.com/user-attachments/assets/56b7b0d3-6ee7-467a-a880-126aa5554c07" />

